### PR TITLE
Added SQL translation

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -11,3 +11,4 @@ If you have a translation that you would like to share please feel free to submi
 - Java by @ysf199711
 - Python by @ysf199711
 - Objective-C by @bidh
+- SQL by @archetypesc

--- a/contrib/sql/README.md
+++ b/contrib/sql/README.md
@@ -1,0 +1,55 @@
+
+# SQL Adaptation of KalmanFilter
+
+Authors:
+
+- @trademark18 at @archetypesc
+
+
+## Example Usage
+
+
+This is a stored procedure that is invoked with 3 parameters:
+
+1. State Identifier `VARCHAR(32)` -- Unique identifier to be used when referencing this filter. A new filter is created if no existing one matches this identifier.
+2. "x" value -- the value to be fed into the filter.
+3. Prediction (output parameter) -- The filter's prediction will be returned in this value.
+  
+
+        -- Example 1
+
+        DECLARE @prediction FLOAT;
+
+        EXEC sp_kalman 'stateIdentifier', 27, @prediction OUTPUT
+
+        SELECT @prediction;
+
+        
+
+        -- Example 2 (more realistic values)
+
+        DECLARE @predictedLatitude FLOAT;
+
+        EXEC sp_kalman 'abcd3fa3b2-lat', 32.7444589, @predictedLatitude OUTPUT
+
+        SELECT @predictedLatitude;
+  
+
+## Caveats
+
+- Unlike the other platforms to which Kalman.JS has been translated, SQL isn't stateful. That's why we have to persist state to a DB table.  The table is called KalmanState.
+
+- If you like, you can create the table yourself, but if you just create the SPROC it will attempt to create the table if it can't find it. If it doesn't have permission or it is otherwise unable to create the KalmanState table, it will throw an error and print out a `CREATE TABLE` script for you to run.
+
+- You can't `EXEC` this inside a transaction that has `SNAPSHOT ISOLATION` enabled, because operations that modify data are incompatible with `SNAPSHOT` and this must modify data in order to update state.
+
+- This doesn't have any mechanism whereby it will delete the state of filters that are no longer needed. You'll need to have your app clean up with something like `DELETE FROM KalmanState WHERE identifier = 'something'`
+
+
+## Advice
+
+- If you don't have a strong reason for which you want to do this in the DB layer, consider using Kalman.JS or another API-level alternative. This is for cases where doing Kalman in the database is necessary.
+
+
+## Improvements
+I found this difficult to bolt into my existing query.  I'd love to find a solution that can be joined to or operate more like a function.  If you have ideas on how to accomplish that, bring them on!

--- a/contrib/sql/sp_kalman.sql
+++ b/contrib/sql/sp_kalman.sql
@@ -1,3 +1,15 @@
+/**
+ * SQL adaptation of the Kalman Filter for 1D data.
+ * Originally written in JavaScript by Wouter Bulten.
+ *
+ * @license MIT License
+ *
+ * @author trademark18 (on behalf of archetypesc)
+ *
+ * @see https://github.com/wouterbulten/kalmanjs
+ *
+ */
+
 SET ANSI_NULLS ON
 GO
 

--- a/contrib/sql/sp_kalman.sql
+++ b/contrib/sql/sp_kalman.sql
@@ -1,0 +1,118 @@
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE OR ALTER PROCEDURE [dbo].[sp_kalman]
+	@identifier VARCHAR(32)
+	,@z FLOAT
+	,@prediction FLOAT OUTPUT
+AS
+BEGIN
+
+SET NOCOUNT ON;
+
+-- Declare variables to be used in Kalman Filter
+DECLARE @R FLOAT = 1;
+DECLARE @Q FLOAT = 1;
+DECLARE @A FLOAT = 1;
+DECLARE @B FLOAT = 0;
+DECLARE @C FLOAT = 1;
+
+DECLARE @cov FLOAT;
+DECLARE @predX FLOAT;
+DECLARE @predCov FLOAT;
+DECLARE @K FLOAT;
+
+DECLARE @x FLOAT = NULL;
+DECLARE @u FLOAT = 0.0;
+
+-- Check to see if state table exists
+IF OBJECT_ID('KalmanState', 'U') IS NULL
+BEGIN
+	BEGIN TRY
+		-- Attempt to create state table
+		CREATE TABLE [dbo].[KalmanState](
+				[id] [int] IDENTITY(1,1) NOT NULL,
+				[x] [float] NULL,
+				[cov] [float] NULL,
+				[predX] [float] NULL,
+				[predCov] [float] NULL,
+				[K] [float] NULL,
+				[identifier] [varchar](32) NOT NULL
+			) ON [PRIMARY]
+	END TRY
+	BEGIN CATCH
+		-- Unable to create table for some reason.  Print a message to the user with the script they need to run
+		PRINT 'KalmanState table doesn''t exist, and the attempt to create it failed (likely insufficient permissions).  Run
+			CREATE TABLE [dbo].[KalmanState](
+				[id] [int] IDENTITY(1,1) NOT NULL,
+				[x] [float] NULL,
+				[cov] [float] NULL,
+				[predX] [float] NULL,
+				[predCov] [float] NULL,
+				[K] [float] NULL,
+				[identifier] [varchar](32) NOT NULL
+			) ON [PRIMARY]
+			GO';
+		RETURN 3; -- Status code 3 for error result https://docs.microsoft.com/en-us/sql/relational-databases/stored-procedures/return-data-from-a-stored-procedure?view=sql-server-ver15#examples-of-return-codes
+	END CATCH
+END
+
+
+-- Populate existing state
+SELECT TOP 1
+	@x = x
+	,@cov = cov
+	,@K = K
+	,@predX = predX
+	,@predCov = predCov
+	FROM KalmanState
+	WHERE identifier = @identifier
+	ORDER BY id DESC
+
+
+-- This code is translated directly from Kalman.js by wouterbulten
+-- https://github.com/wouterbulten/kalmanjs
+-- https://github.com/wouterbulten/kalmanjs/blob/713bb61799fe508a79868a123c916db75ee7a777/dist/kalman.js#L84
+IF (@x IS NULL)
+BEGIN
+	PRINT 'No existing state; proceeding without it';
+	SET @x = 1 / @C * @z;
+	SET @cov = 1 / @C * @Q * (1 / @C);
+END
+ELSE
+BEGIN
+	SET @predX = @A * @x + @B * @u;
+	SET @predCov = @A * @cov * @A + @R;
+
+	SET @K = @predCov * @C * (1 / (@C * @predCov * @C + @Q));
+
+	SET @x = @predX + @K * (@z - @C * @predX);
+	SET @cov = @predCov - @K * @C * @predCov;
+
+END
+
+
+-- Clear any existing state
+DELETE FROM KalmanState WHERE identifier = @identifier;
+
+-- Save state
+INSERT INTO KalmanState
+VALUES
+(
+	@x
+	,@cov
+	,@predX
+	,@predCov
+	,@K
+	,@identifier
+)
+
+-- Select final prediction
+SET @prediction = @x;
+RETURN 0; -- Clean exit status code
+
+END
+GO


### PR DESCRIPTION
Hello!  

TL;DR: SQL Port for Kalman.JS

I've used Kalman.JS for years and enjoyed it's simple interface and great utility in many of my projects (work and personal).  I found myself wanting to filter values at a very specific point in my data processing pipeline, such that it needed to happen inside the database. 

I just did a direct translation of the math (which I still don't understand 😄) and I solved the SQL-specific challenge of state persistence in a not-perfect-but-functional way.  Please feel free to push back on anything that bears reviewing.